### PR TITLE
Fixed minor typos, include reference on felts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,20 +5,20 @@ Get started with Cairo with this simple tutorial. Complete the puzzles, get poin
 ### Disclaimer
 Don't expect any kind of benefit from using this, other than learning a bunch of cool stuff about StarNet, the first general purpose validity rollup on the Ethereum Mainnnet. 
 
-StarkNet is still in Alpha. This means that develpment is ongoing, and the paint is not dry everywhere. Things will get better, and in the meanwhile, we make things work with a bit of duct tape here and there!
+StarkNet is still in Alpha. This means that development is ongoing, and the paint is not dry everywhere. Things will get better, and in the meanwhile, we make things work with a bit of duct tape here and there!
 
 ### How it works
 This workshop is a set of smart contracts deployed on StarkNet Alpha on testnet. Each smart contract is an exercice/puzzle; each one outlines a feature of the Cairo Smart contract language. Completing the exercice will credit you with points, in the form of an [ERC20 token](contracts/token/TDERC20.cairo).
 
 This workshop focuses on *reading* Cairo code and StarkNet smart contracts, in order to understand its syntax. You don't need to code or install anything on your machine in order to follow and complete it. Getting started (doing the first two exercises) will take you some time, in order to get into the tutorial. Hang on! Once there, things will flow more easily. You're learning!
 
-This workshop is the first in a serie that will cover broad smart contract concepts (writing and deploying ERC20/ERC721, bridging assets, L1 <-> L2 messaging...). 
+This workshop is the first in a series that will cover broad smart contract concepts (writing and deploying ERC20/ERC721, bridging assets, L1 <-> L2 messaging...). 
 Interested in helping writing those? [Reach out](https://twitter.com/HenriLieutaud)!
 
 ### Providing feedback & getting support 
 Once you are done working on this tutorial, your feedback would be greatly appreciated! Please fill [this form](https://forms.reform.app/starkware/untitled-form-4/kaes2e) to let us know what we can do to make it better. And if you struggle to move forward, do let us know! This workshop is meant to be as accessible as possible; we want to know if it's not the case.
 
-Do you have a question? Join our [Discord server](https://discord.gg/YHz7drT3), register and join chanel #tutorials-support
+Do you have a question? Join our [Discord server](https://discord.gg/YHz7drT3), register and join channel #tutorials-support
 
 ## Getting started
 ### What will change soon
@@ -61,7 +61,7 @@ Your points will get credited in Argent X; though this make take so time. If you
 - Enter your address in decimal in the "balanceOf" function
 
 #### Transaction status
-You sent a transaction, and it is shown as "undected" in voyager? This can mean two things:
+You sent a transaction, and it is shown as "undetected" in voyager? This can mean two things:
 - Your transaction is pending, and will be included in a block shortly. It will then be visible in voyager.
 - Your transaction was invalid, and will NOT be included in a block (there is no such thing as a failed transaction in StarkNet). 
 

--- a/contracts/ex01.cairo
+++ b/contracts/ex01.cairo
@@ -42,7 +42,7 @@ end
 #
 
 # This function is called claim_points
-# It takes one argument as a parameter (sender_address), which is a felt. Read more about felts here TODO
+# It takes one argument as a parameter (sender_address), which is a felt. Read more about felts here https://www.cairo-lang.org/docs/hello_cairo/intro.html#field-element
 # It also has implicit arguments (syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr). Read more about implicit arguments here TODO
 @external
 func claim_points{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(sender_address: felt):

--- a/contracts/ex02.cairo
+++ b/contracts/ex02.cairo
@@ -35,7 +35,7 @@ from contracts.utils.ex00_base import (
 # Storage vars are by default not visible through the ABI. They are similar to "private" variables in Solidity
 #
 # This variable is a felt and is called my_secret_value_storage
-# From within a smart contract, it can be read wtht my_secret_value_storage.read() or written to with my_secret_value_storage.write()
+# From within a smart contract, it can be read with my_secret_value_storage.read() or written to with my_secret_value_storage.write()
 
 @storage_var
 func my_secret_value_storage() -> (my_secret_value_storage: felt):
@@ -43,7 +43,7 @@ end
 
 #
 # Declaring getters
-# Public variables should be declared explicitely with a getter
+# Public variables should be declared explicitly with a getter
 #
 
 

--- a/contracts/ex03.cairo
+++ b/contracts/ex03.cairo
@@ -41,7 +41,7 @@ end
 
 #
 # Declaring getters
-# Public variables should be declared explicitely with a getter
+# Public variables should be declared explicitly with a getter
 #
 
 # Declaring a getter for our mappings. It takes one argument as a parameter, the account you wish to read the counter of

--- a/contracts/ex04.cairo
+++ b/contracts/ex04.cairo
@@ -47,7 +47,7 @@ end
 
 #
 # Declaring getters
-# Public variables should be declared explicitely with a getter
+# Public variables should be declared explicitly with a getter
 #
 
 @view

--- a/contracts/ex05.cairo
+++ b/contracts/ex05.cairo
@@ -51,7 +51,7 @@ end
 
 #
 # Declaring getters
-# Public variables should be declared explicitely with a getter
+# Public variables should be declared explicitly with a getter
 #
 
 @view

--- a/contracts/ex06.cairo
+++ b/contracts/ex06.cairo
@@ -49,7 +49,7 @@ end
 
 #
 # Declaring getters
-# Public variables should be declared explicitely with a getter
+# Public variables should be declared explicitly with a getter
 #
 
 @view

--- a/contracts/ex08.cairo
+++ b/contracts/ex08.cairo
@@ -32,7 +32,7 @@ end
 
 #
 # Declaring getters
-# Public variables should be declared explicitely with a getter
+# Public variables should be declared explicitly with a getter
 #
 
 @view

--- a/contracts/ex10.cairo
+++ b/contracts/ex10.cairo
@@ -65,7 +65,7 @@ func claim_points{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_
     let (secret_value) = Iex10b.secret_value(contract_address=ex10b_address)
     assert secret_value = secret_value_i_guess
 
-    # chosing next secret_value for contract 10b. We don't want 0, it's not funny
+    # choosing next secret_value for contract 10b. We don't want 0, it's not funny
     assert_not_zero(next_secret_value_i_chose)
     Iex10b.change_secret_value(contract_address=ex10b_address, new_secret_value= next_secret_value_i_chose)
 

--- a/contracts/utils/ex00_base.cairo
+++ b/contracts/utils/ex00_base.cairo
@@ -81,10 +81,10 @@ end
 func validate_exercice{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(to: felt):
 	# Checking if the user has deployed an account contract
 	let (account_contract_signer) = IAccountContract.get_signer(contract_address=to)
-	# Veryfing that the account contract has a valid signer
+	# Verifying that the account contract has a valid signer
 	assert_not_zero(account_contract_signer)
 
-	# Checking if the user already validater this exercice
+	# Checking if the user already validated this exercice
 	let (has_current_user_validated_exercice) = has_validated_exercice_storage.read(to)
 	assert (has_current_user_validated_exercice) = 0
 

--- a/contracts/utils/ex11_base.cairo
+++ b/contracts/utils/ex11_base.cairo
@@ -35,7 +35,7 @@ end
 
 #
 # Declaring getters
-# Public variables should be declared explicitely with a getter
+# Public variables should be declared explicitly with a getter
 #
 
 @view
@@ -99,10 +99,10 @@ end
 func validate_exercice{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(to: felt):
     # Checking if the user has deployed an account contract
     let (account_contract_signer) = IAccountContract.get_signer(contract_address=to)
-    # Veryfing that the account contract has a valid signer
+    # Verifying that the account contract has a valid signer
     assert_not_zero(account_contract_signer)
 
-    # Checking if the user already validater this exercice
+    # Checking if the user already validated this exercice
     let (has_current_user_validated_exercice) = has_validated_exercice_storage.read(to)
     assert (has_current_user_validated_exercice) = 0
 


### PR DESCRIPTION
Fixed a few minor typos and included a pointer to the felt documentation.

I've noticed that unfortunately almost always the word `exercice` -> `èxercise` was misspelled. This however also affects function names and would require redeployment. Should I replace them?