### PR TITLE
prevent counting cairo as python in repo stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.cairo linguist-language=python
+*.cairo linguist-language=python linguist-detectable=false

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Do you have a question? Join our [Discord server](https://discord.gg/YHz7drT3), 
 ### What will change soon
 ​
 -   As of 05/01/2021, transactions in StarkNet can still be done without an account contract. This tutorial currently leverages this possibility. Once account contracts become more widespread and usable, it will change to reflect that.
--   Voyager struggles with hexadecimal / decimal conversion. For now, you should input all your value in voyager in the decimal format
+-   Voyager struggles with hexadecimal / decimal conversion. For now, you should input all your values in voyager in decimal format
 ​
 ### Creating an account contract
 **In order to complete the tutorial you need to collect points.** These points will be owned by a smart contract wallet, that you need to deploy.


### PR DESCRIPTION
Following https://github.com/l-henri/starknet-cairo-101/pull/5, although maybe not as directly useful.

This commit prevents counting .cairo as Python files in repo stats while keeping syntax highlighting. See result here: https://github.com/trevis-dev/starknet-cairo-101/tree/trevis-dev-patch-1.

Its effect could be visible only after the next push though, see ​​https://github.com/github/linguist/blob/master/docs/how-linguist-works.md#how-linguist-works-on-githubcom

Hopefully this will be irrelevant soon with the introduction of Cairo in [linguist languages](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml) (see https://github.com/github/linguist/pull/5661) and Github.

edit: fixed syntax and added actual change to README