### PR TITLE
typo: length on first reach

### DIFF
--- a/contracts/ex08.cairo
+++ b/contracts/ex08.cairo
@@ -101,7 +101,7 @@ func set_user_values_internal{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
     # If length is NOT zero, then the function calls itself again, moving forward one slot
     set_user_values_internal(account = account, length=length - 1, array=array + 1)
 
-    # This part of the function is first reached when length=0.
+    # This part of the function is first reached when length=1.
     user_values_storage.write(account, length - 1, [array])
     return ()
 end


### PR DESCRIPTION
Hey there,

```py
func set_user_values_internal{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(account:felt, length : felt, array : felt*):
    # This function is used recursively to set all the user values
    # Recursively, we first go through the length of the array
    # Once at the end of the array (length = 0), we start summing
    if length == 0:
        # Start with sum=0.
        return ()
    end

    # If length is NOT zero, then the function calls itself again, moving forward one slot
    set_user_values_internal(account = account, length=length - 1, array=array + 1)

    # This part of the function is first reached when length=1.
    user_values_storage.write(account, length - 1, [array])
    return ()
end
```

I just updated this comment: `` # This part of the function is first reached when length=0.``

I think the return is reached when length=0 and this last part of the code will be called with length = 1, 2, 3, etc

Have a nice day,
Thomas