### PR TITLE
docs(ex1): add explicit arguments documentation

### DIFF
--- a/contracts/ex01.cairo
+++ b/contracts/ex01.cairo
@@ -48,7 +48,7 @@ end
 
 # This function is called claim_points
 # It takes one argument as a parameter (sender_address), which is a felt. Read more about felts here https://www.cairo-lang.org/docs/hello_cairo/intro.html#field-element
-# It also has implicit arguments (syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr). Read more about implicit arguments here TODO
+# It also has implicit arguments (syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr). Read more about implicit arguments here https://www.cairo-lang.org/docs/how_cairo_works/builtins.html
 @external
 func claim_points{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
     # Reading caller address


### PR DESCRIPTION
Add a link to the official Cairo documentation that explains implicit arguments.