### PR TITLE
Ex11: set new secret value

### DIFF
--- a/contracts/utils/ex11_base.cairo
+++ b/contracts/utils/ex11_base.cairo
@@ -172,16 +172,22 @@ func validate_answers{
         tempvar pedersen_ptr = pedersen_ptr
         tempvar range_check_ptr = range_check_ptr
     else:
-        # If secret value is correct, do nothing and move on
+        # If secret value is correct, set new secret value
         if diff == 0:
+            assert_not_zero(next_secret_value_i_chose)
+            ex11_secret_value.write(next_secret_value_i_chose)
+            # This is necessary because of revoked references. Don't be scared, they won't stay around for too long...
+            tempvar syscall_ptr = syscall_ptr
+            tempvar pedersen_ptr = pedersen_ptr
+            tempvar range_check_ptr = range_check_ptr
         # If secret value is incorrect, we revert
         else:
             assert 1 = 0
+            # This is necessary because of revoked references. Don't be scared, they won't stay around for too long...
+            tempvar syscall_ptr = syscall_ptr
+            tempvar pedersen_ptr = pedersen_ptr
+            tempvar range_check_ptr = range_check_ptr
         end
-        # This is necessary because of revoked references. Don't be scared, they won't stay around for too long...
-        tempvar syscall_ptr = syscall_ptr
-        tempvar pedersen_ptr = pedersen_ptr
-        tempvar range_check_ptr = range_check_ptr
     end
 
     return ()


### PR DESCRIPTION
In "ex11", there is an input param `next_secret_value_i_chose` for the function `validate_answers` that stays unused
https://github.com/l-henri/starknet-cairo-101/blob/295b235812412985edc6d82c80d53b6d7b336790/contracts/utils/ex11_base.cairo#L154

This PR fixes this in the case the first param is valid.
Steps:
1. check `next_secret_value_i_chose` is not 0
2. write the value of `next_secret_value_i_chose` to `ex11_secret_value`
