### PR TITLE
expected value does not teach users, a minor suggestion

### DIFF
--- a/contracts/ex05.cairo
+++ b/contracts/ex05.cairo
@@ -97,7 +97,7 @@ func claim_points{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_
     # Checking that the value provided by the user is the one we expect
     # Still sneaky.
     let (value) = values_mapped_secret_storage.read(user_slot)
-    assert value = expected_value + 23
+    assert value = expected_value - 23
 
     # Checking if the user has validated the exercice before
     validate_exercise(sender_address)


### PR DESCRIPTION
For example:
1. secret_value is 50
2. after copy_secret_value_to_readable_mapping(), public value is 50-23=27
3. for the original behavior 
```
assert value = expected_value + 23
```
expected value will just be 27 - the same as public value - which means users can just pass the parameter expected_value as whatever they've seen from the reading the public value of their address from the contract.

It makes sense if it's been changed to something else, so that at least users won't falsely/accidently assume they understand it, they have to read all the lines correctly, and did the calculations in their mind twice.