### PR TITLE
Remove unused var

### DIFF
--- a/contracts/ex11.cairo
+++ b/contracts/ex11.cairo
@@ -45,11 +45,11 @@ end
 #
 
 @external
-func claim_points{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(secret_value_i_guess: felt, next_secret_value_i_chose: felt):
+func claim_points{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(secret_value_i_guess: felt):
     # Reading caller address
     let (sender_address) = get_caller_address()
     # Check if your answer is correct
-    validate_answers(sender_address, secret_value_i_guess, next_secret_value_i_chose)
+    validate_answers(sender_address, secret_value_i_guess)
     # Reading caller address again, revoked references I love you
     let (sender_address) = get_caller_address()
     # Checking if the user has validated the exercice before

--- a/contracts/utils/ex11_base.cairo
+++ b/contracts/utils/ex11_base.cairo
@@ -151,7 +151,7 @@ func validate_answers{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }(sender_address: felt, secret_value_i_guess: felt, next_secret_value_i_chose: felt):
+    }(sender_address: felt, secret_value_i_guess: felt):
     # CAREFUL THERE IS A TRAP FOR PEOPLE WHO WON'T READ THE CODE
     # This exercice looks like the previous one, but actually the view secret_value returns a different value than secret_value
     # Sending the wrong execution result will remove some of your points, then validate the exercice. You won't be able to get those points back later on!


### PR DESCRIPTION
I searched the repo, but couldn't find any references that's using this var. (Please reject the PR if I'm wrong)
Guess after ex10 has been updated, this var is no longer needed in ex11_base/ex11, so I removed it.