### PR TITLE
Move Exercise 12 to correct position in list and fix some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ StarkNet is still in Alpha. This means that development is ongoing, and the pain
 ​
 **Complete the exercises and get tokens!**
 This workshop is a set of smart contracts deployed on StarkNet Alpha on testnet. 
-Each smart contract is an exercice/puzzle - which outlines a feature of the Cairo Smart contract language. 
-Completing the exercice will credit you with points, in the form of an [ERC20 token](contracts/token/TDERC20.cairo).
+Each smart contract is an exercise/puzzle - which outlines a feature of the Cairo Smart contract language. 
+Completing the exercise will credit you with points, in the form of an [ERC20 token](contracts/token/TDERC20.cairo).
 ​
 This workshop focuses on *reading* Cairo code and StarkNet smart contracts, in order to understand its syntax. 
 You do not need to code or install anything on your machine in order to follow and complete it. 
@@ -55,9 +55,9 @@ When looking for a contract / transaction, always make sure you are on the Goerl
 ### Getting points
 ​
 ​
-**Each exercice is a separate smart contract.** It contains code that, when executed properly, will distribute points to your address. Since there is no way currently to send a transaction easily through your account contract, you'll have to specify your address for each call.
+**Each exercise is a separate smart contract.** It contains code that, when executed properly, will distribute points to your address. Since there is no way currently to send a transaction easily through your account contract, you'll have to specify your address for each call.
 ​
-Points are distributed by the function `distribute_points()` while the function `validate_exercice` records that you completed the exercice (you can get points only once). Your goal is to: 
+Points are distributed by the function `distribute_points()` while the function `validate_exercise` records that you completed the exercise (you can get points only once). Your goal is to: 
 
 ![Graph](assets/diagram.png)
 ​
@@ -91,13 +91,13 @@ You can (and should) check the status of your transaction with the following URL
 |Reading and writing storage variables|[Ex03](contracts/ex03.cairo)|[Link](https://goerli.voyager.online/contract/0x044a68c9052a5208a46aee5d0af6f6a3e30686ab9ce3e852c4b817d0a76f2f09)|
 |Mappings|[Ex04](contracts/ex04.cairo)|[Link](https://goerli.voyager.online/contract/0x04e701814214c5d82215a134c31029986b0d05a2592c0c977fe2330263dc7304)|
 |Variable visibility|[Ex05](contracts/ex05.cairo)|[Link](https://goerli.voyager.online/contract/0x01e7285636d7d147df6e2eacb044611e13ce79048c4ac21d0209c8c923108975)|
-|Events|[Ex12](contracts/ex12.cairo)|[Link](https://goerli.voyager.online/contract/0x0658e159d61d4428b6d5fa90aa20083786674c49a645fe416fc4c35b145f8a83)|
 |Functions visibility|[Ex06](contracts/ex06.cairo)|[Link](https://goerli.voyager.online/contract/0x02abaa69541bd4630225cd69fa87d08a6e8fb80f4c7c2e8d3568fa59e71eec26)|
 |Comparing values|[Ex07](contracts/ex07.cairo)|[Link](https://goerli.voyager.online/contract/0x07d9f4f818592b7a97f2c7e5915733ed022f96313cb61bde2c27a9fbd729a5a4)|
 |Recursions level 1|[Ex08](contracts/ex08.cairo)|[Link](https://goerli.voyager.online/contract/0x072d42eb599c9ec14d1f7209223226cb1436898c6930480c6a2f6998c6ceb9fe)|
 |Recursions level 2|[Ex09](contracts/ex09.cairo)|[Link](https://goerli.voyager.online/contract/0x035203b6c0b68ef87127a7d77f36de4279ceb79ea2d8099f854f51fc28074de4)|
 |Composability|[Ex10](contracts/ex10.cairo)|[Link](https://goerli.voyager.online/contract/0x071e59fbd7e724b94ad1f6d4bba1ff7161a834c6b19c4b88719ad640d5a6105c)|
 |Importing functions|[Ex11](contracts/ex11.cairo)|[Link](https://goerli.voyager.online/contract/0x06e124eba8dcf1ebe207d6adb366193511373801b49742b39ace5c868b795e68)|
+|Events|[Ex12](contracts/ex12.cairo)|[Link](https://goerli.voyager.online/contract/0x0658e159d61d4428b6d5fa90aa20083786674c49a645fe416fc4c35b145f8a83)|
 |Privacy on StarkNet|[Ex13](contracts/ex13.cairo)|[Link](https://goerli.voyager.online/contract/0x07b271402ce18e1bcc1b64f555cdc23693b0eb091d71644f72b6c220814c1425)|
 
 ​
@@ -106,8 +106,8 @@ You can (and should) check the status of your transaction with the following URL
 ### Help is welcome!
 This project can be made better, and will evolve in the coming weeks. Your contributions are welcome! Here are things that you can do to help:
 - Correct bugs if you find some
-- Add explanation in the comments of the exercice if you feel it needs more explanation
-- Add exercices showcasing your favorite Cairo feature
+- Add explanation in the comments of the exercise if you feel it needs more explanation
+- Add exercises showcasing your favorite Cairo feature
 ​
 ### Reusing this project
 - Clone the repo on your machine


### PR DESCRIPTION
Fixing the exercise list by moving Ex12 to the right position. Also fixing some typos.